### PR TITLE
keyword-list: remove , from valid characters for keywords

### DIFF
--- a/tscat_gui/utils/keyword_list.py
+++ b/tscat_gui/utils/keyword_list.py
@@ -7,7 +7,7 @@ import re
 import typing
 
 # UTF-8 letters in the beginning, then also numbers and underscore
-_tag_validation_regex = re.compile(r'[a-z]\w*')
+_tag_validation_regex = re.compile(r'^[a-z][^,]*$')
 
 
 class _Keyword(EditableLabel):


### PR DESCRIPTION
Works best in junction latest, when merged, tscat, but also without.