### PR TITLE
Ensure driver worker is always async and models are updated in the right thread

### DIFF
--- a/tscat_gui/tscat_driver/catalog_model.py
+++ b/tscat_gui/tscat_driver/catalog_model.py
@@ -20,7 +20,7 @@ class CatalogModel(QAbstractTableModel):
         super().__init__()
         self._root = root
         self._trash = TrashNode()
-        tscat_driver.action_done_prioritised.connect(self._driver_action_done)
+        tscat_driver.action_done_prioritised.connect(self._driver_action_done, Qt.QueuedConnection)
 
     def _driver_action_done(self, action: Action) -> None:
         if isinstance(action, GetCatalogueAction):

--- a/tscat_gui/tscat_driver/driver.py
+++ b/tscat_gui/tscat_driver/driver.py
@@ -1,7 +1,7 @@
 import atexit
 from typing import Dict, Union, Optional
 
-from PySide6.QtCore import QObject, QThread, Slot, Signal
+from PySide6.QtCore import QObject, QThread, Slot, Signal, Qt
 from tscat import _Catalogue, _Event
 
 from .actions import Action, GetCataloguesAction, GetCatalogueAction, CreateEntityAction, RemoveEntitiesAction, \
@@ -34,8 +34,8 @@ class TscatDriver(QObject):
 
         self._worker = _TscatDriverWorker()
 
-        self._do_action.connect(self._worker.do_action)
-        self._worker.action_done.connect(self._worker_action_done)
+        self._do_action.connect(self._worker.do_action, Qt.QueuedConnection)
+        self._worker.action_done.connect(self._worker_action_done, Qt.QueuedConnection)
 
         self._entity_cache: Dict[str, Union[_Event, _Catalogue]] = {}
         self.destroyed.connect(self.stop)  # type: ignore

--- a/tscat_gui/tscat_driver/tscat_root_model.py
+++ b/tscat_gui/tscat_driver/tscat_root_model.py
@@ -30,7 +30,7 @@ class TscatRootModel(QAbstractItemModel):
 
         self._catalogues: Dict[str, CatalogModel] = {}
 
-        tscat_driver.action_done_prioritised.connect(self._driver_action_done)
+        tscat_driver.action_done_prioritised.connect(self._driver_action_done, Qt.QueuedConnection)
 
         tscat_driver.do(GetCataloguesAction(None, False))
         tscat_driver.do(GetCataloguesAction(None, True))


### PR DESCRIPTION
This was causing segfaults in SciQLop with several views/proxy models plugged to the same model.