### PR TITLE
Add story-driven UI fuzzing framework

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "PySide6",
-    "tscat==0.4.*",
+    "tscat>=0.5.1,<0.6",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ test = [
     "pytest-cov",
     "pytest-timeout",
     "pytest-qt",
+    "hypothesis",
     "ddt",
     "mypy",
     "ruff>=0.15.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,11 @@ testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 120
+exclude = ["test-reports"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W"]
-exclude = ["docs"]
+exclude = ["docs", "test-reports"]
 
 [dependency-groups]
 dev = [

--- a/tests/fuzzing/actions.py
+++ b/tests/fuzzing/actions.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 from hypothesis.stateful import (
-    Bundle,
     RuleBasedStateMachine,
     rule,
     precondition,
@@ -17,6 +16,14 @@ from PySide6.QtWidgets import QApplication
 
 from tests.fuzzing.model import AppModel
 from tests.fuzzing.story import Step, Story
+
+
+class _Skip:
+    """Sentinel returned by actions to skip model_update and verify."""
+    pass
+
+
+SKIP = _Skip()
 
 
 @dataclass
@@ -78,6 +85,14 @@ def _bind_kwargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in kwargs.items() if k in params}
 
 
+def _defaults_for(fn: Callable) -> dict[str, Any]:
+    defaults = {}
+    for name, param in inspect.signature(fn).parameters.items():
+        if param.default is not inspect.Parameter.empty:
+            defaults[name] = param.default
+    return defaults
+
+
 def run_action(fn: Callable, gui, model: AppModel, story: Story, **kwargs) -> Any:
     meta: ActionMeta = fn._ui_meta
 
@@ -98,12 +113,18 @@ def run_action(fn: Callable, gui, model: AppModel, story: Story, **kwargs) -> An
         _dump_story(story)
         raise
 
+    if isinstance(result, _Skip):
+        if not meta.manages_own_snapshots:
+            model.pop_snapshot()
+        return None
+
+    effective_kwargs = {**_defaults_for(fn), **kwargs}
     if isinstance(result, dict):
-        cb_kwargs = {**kwargs, **result, "result": result}
+        cb_kwargs = {**effective_kwargs, **result, "result": result}
         narrate_args = {k: str(v) for k, v in result.items()}
     else:
-        cb_kwargs = {**kwargs, "result": result}
-        narrate_args = {k: str(v) for k, v in kwargs.items()}
+        cb_kwargs = {**effective_kwargs, "result": result}
+        narrate_args = {k: str(v) for k, v in effective_kwargs.items()}
         if result is not None:
             narrate_args["result"] = str(result)
 
@@ -137,6 +158,10 @@ def _reset_tscat_backend(gui) -> None:
     from tscat_gui.tscat_driver.driver import tscat_driver
     from tscat_gui.tscat_driver.actions import GetCataloguesAction
     import tscat
+
+    gui.catalogues_view.selectionModel().clearSelection()
+    gui.events_view.selectionModel().clearSelection()
+    settle(200)
 
     gui.state.undo_stack().clear()
 
@@ -186,15 +211,7 @@ class ActionRegistry:
         stateful_step_count: int = 15,
     ) -> type:
         registry = self
-        bundles_map: dict[str, Bundle] = {}
-
-        for action_fn in registry.actions:
-            meta: ActionMeta = action_fn._ui_meta
-            if meta.target and meta.target not in bundles_map:
-                bundles_map[meta.target] = Bundle(meta.target)
-
         class_dict: dict[str, Any] = {}
-        class_dict.update(bundles_map)
 
         @initialize()
         def _init_model(self):
@@ -221,17 +238,12 @@ class ActionRegistry:
             method_name = action_fn.__name__
 
             rule_kwargs: dict[str, Any] = {}
-            if meta.target:
-                rule_kwargs["target"] = bundles_map[meta.target]
-
-            for param_name, bundle_name in (meta.bundles or {}).items():
-                rule_kwargs[param_name] = bundles_map[bundle_name]
             for param_name, strategy in (meta.strategies or {}).items():
                 rule_kwargs[param_name] = strategy
 
             def make_rule_method(fn, fn_meta):
                 def rule_method(self, **kwargs):
-                    return run_action(
+                    run_action(
                         fn,
                         self.__class__.gui,
                         self._model,

--- a/tests/fuzzing/actions.py
+++ b/tests/fuzzing/actions.py
@@ -141,7 +141,8 @@ def _reset_tscat_backend(gui) -> None:
     gui.state.undo_stack().clear()
 
     for cat in tscat.get_catalogues() + tscat.get_catalogues(removed_items=True):
-        tscat.discard(cat, permanently=True)
+        cat.remove(permanently=True)
+    tscat.save()
 
     tscat_driver._entity_cache.clear()
 

--- a/tests/fuzzing/actions.py
+++ b/tests/fuzzing/actions.py
@@ -94,7 +94,7 @@ def _defaults_for(fn: Callable) -> dict[str, Any]:
 
 
 def run_action(fn: Callable, gui, model: AppModel, story: Story, **kwargs) -> Any:
-    meta: ActionMeta = fn._ui_meta
+    meta: ActionMeta = fn._ui_meta  # type: ignore[attr-defined]
 
     if not meta.manages_own_snapshots:
         model.push_snapshot()
@@ -234,7 +234,7 @@ class ActionRegistry:
         class_dict["teardown"] = teardown
 
         for action_fn in registry.actions:
-            meta: ActionMeta = action_fn._ui_meta
+            meta: ActionMeta = action_fn._ui_meta  # type: ignore[attr-defined]
             method_name = action_fn.__name__
 
             rule_kwargs: dict[str, Any] = {}
@@ -259,7 +259,7 @@ class ActionRegistry:
             if meta.precondition:
                 user_precond = meta.precondition
                 method = precondition(
-                    lambda self, _p=user_precond: _p(self._model)
+                    lambda self, _p=user_precond: _p(self._model)  # type: ignore[misc]
                 )(method)
 
             method = rule(**rule_kwargs)(method)
@@ -267,7 +267,7 @@ class ActionRegistry:
 
         sm_class = type(name, (RuleBasedStateMachine,), class_dict)
 
-        sm_class.TestCase.settings = hypothesis_settings(
+        sm_class.TestCase.settings = hypothesis_settings(  # type: ignore[attr-defined]
             max_examples=max_examples,
             stateful_step_count=stateful_step_count,
             deadline=None,

--- a/tests/fuzzing/actions.py
+++ b/tests/fuzzing/actions.py
@@ -164,6 +164,7 @@ def _reset_tscat_backend(gui) -> None:
     settle(200)
 
     gui.state.undo_stack().clear()
+    gui.state.updated('active_select', tscat._Catalogue, [])
 
     for cat in tscat.get_catalogues() + tscat.get_catalogues(removed_items=True):
         cat.remove(permanently=True)
@@ -215,6 +216,7 @@ class ActionRegistry:
 
         @initialize()
         def _init_model(self):
+            _reset_tscat_backend(self.__class__.gui)
             self._model = AppModel()
             self._story = Story()
 
@@ -229,7 +231,7 @@ class ActionRegistry:
                 _reset_tscat_backend(self.__class__.gui)
             except Exception:
                 pass
-            settle()
+            settle(500)
 
         class_dict["teardown"] = teardown
 
@@ -271,6 +273,7 @@ class ActionRegistry:
             max_examples=max_examples,
             stateful_step_count=stateful_step_count,
             deadline=None,
+            database=None,
         )
 
         return sm_class

--- a/tests/fuzzing/actions.py
+++ b/tests/fuzzing/actions.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import inspect
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    rule,
+    precondition,
+    initialize,
+)
+from hypothesis import settings as hypothesis_settings
+from PySide6.QtWidgets import QApplication
+
+from tests.fuzzing.model import AppModel
+from tests.fuzzing.story import Step, Story
+
+
+@dataclass
+class ActionMeta:
+    narrate: str
+    model_update: Callable
+    verify: Callable
+    precondition: Callable | None = None
+    target: str | None = None
+    bundles: dict[str, str] | None = None
+    strategies: dict[str, Any] | None = None
+    settle_timeout_ms: int = 200
+    manages_own_snapshots: bool = False
+
+
+def ui_action(
+    *,
+    narrate: str,
+    model_update: Callable,
+    verify: Callable,
+    precondition: Callable | None = None,
+    target: str | None = None,
+    bundles: dict[str, str] | None = None,
+    strategies: dict[str, Any] | None = None,
+    settle_timeout_ms: int = 200,
+    manages_own_snapshots: bool = False,
+):
+    meta = ActionMeta(
+        narrate=narrate,
+        model_update=model_update,
+        verify=verify,
+        precondition=precondition,
+        target=target,
+        bundles=bundles,
+        strategies=strategies,
+        settle_timeout_ms=settle_timeout_ms,
+        manages_own_snapshots=manages_own_snapshots,
+    )
+
+    def decorator(fn):
+        fn._ui_meta = meta
+        return fn
+
+    return decorator
+
+
+def settle(timeout_ms: int = 200):
+    app = QApplication.instance()
+    if app is None:
+        return
+    deadline = time.monotonic() + timeout_ms / 1000.0
+    while time.monotonic() < deadline:
+        app.processEvents()
+        time.sleep(0.001)
+
+
+def _bind_kwargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
+    params = set(inspect.signature(fn).parameters.keys())
+    return {k: v for k, v in kwargs.items() if k in params}
+
+
+def run_action(fn: Callable, gui, model: AppModel, story: Story, **kwargs) -> Any:
+    meta: ActionMeta = fn._ui_meta
+
+    if not meta.manages_own_snapshots:
+        model.push_snapshot()
+
+    try:
+        result = fn(gui, model, **kwargs)
+    except Exception as e:
+        narrate_args = {k: str(v) for k, v in kwargs.items()}
+        step = Step(
+            action_name=fn.__name__,
+            args=narrate_args,
+            narrate_template=meta.narrate,
+            error=e,
+        )
+        story.record(step)
+        _dump_story(story)
+        raise
+
+    if isinstance(result, dict):
+        cb_kwargs = {**kwargs, **result, "result": result}
+        narrate_args = {k: str(v) for k, v in result.items()}
+    else:
+        cb_kwargs = {**kwargs, "result": result}
+        narrate_args = {k: str(v) for k, v in kwargs.items()}
+        if result is not None:
+            narrate_args["result"] = str(result)
+
+    step = Step(
+        action_name=fn.__name__,
+        args=narrate_args,
+        narrate_template=meta.narrate,
+        result=result if not isinstance(result, dict) else None,
+    )
+    story.record(step)
+
+    settle(meta.settle_timeout_ms)
+
+    model_kwargs = _bind_kwargs(meta.model_update, cb_kwargs)
+    meta.model_update(model, **model_kwargs)
+
+    verify_kwargs = _bind_kwargs(meta.verify, cb_kwargs)
+    try:
+        ok = meta.verify(gui, model, **verify_kwargs)
+        if ok is False:
+            raise AssertionError(f"Verification failed after {fn.__name__}")
+    except Exception as e:
+        story.steps[-1].error = e
+        _dump_story(story)
+        raise
+
+    return result
+
+
+def _reset_tscat_backend(gui) -> None:
+    from tscat_gui.tscat_driver.driver import tscat_driver
+    from tscat_gui.tscat_driver.actions import GetCataloguesAction
+    import tscat
+
+    gui.state.undo_stack().clear()
+
+    for cat in tscat.get_catalogues() + tscat.get_catalogues(removed_items=True):
+        tscat.discard(cat, permanently=True)
+
+    tscat_driver._entity_cache.clear()
+
+    tscat_driver.do(GetCataloguesAction(None, False))
+    tscat_driver.do(GetCataloguesAction(None, True))
+    settle(500)
+
+
+class StoryRunner:
+    def __init__(self, gui):
+        self.gui = gui
+        self.model = AppModel()
+        self.story = Story()
+
+    def run(self, action_fn: Callable, **kwargs) -> Any:
+        return run_action(action_fn, self.gui, self.model, self.story, **kwargs)
+
+    def cleanup(self):
+        try:
+            _reset_tscat_backend(self.gui)
+        except Exception:
+            pass
+        settle()
+
+
+class ActionRegistry:
+    def __init__(self):
+        self.actions: list[Callable] = []
+
+    def register(self, fn: Callable) -> Callable:
+        if not hasattr(fn, "_ui_meta"):
+            raise ValueError(f"{fn.__name__} must be decorated with @ui_action")
+        self.actions.append(fn)
+        return fn
+
+    def build_state_machine(
+        self,
+        name: str = "UIFuzzTest",
+        *,
+        max_examples: int = 10,
+        stateful_step_count: int = 15,
+    ) -> type:
+        registry = self
+        bundles_map: dict[str, Bundle] = {}
+
+        for action_fn in registry.actions:
+            meta: ActionMeta = action_fn._ui_meta
+            if meta.target and meta.target not in bundles_map:
+                bundles_map[meta.target] = Bundle(meta.target)
+
+        class_dict: dict[str, Any] = {}
+        class_dict.update(bundles_map)
+
+        @initialize()
+        def _init_model(self):
+            self._model = AppModel()
+            self._story = Story()
+
+        class_dict["_init_model"] = _init_model
+
+        def teardown(self):
+            if self._story.steps:
+                last = self._story.steps[-1]
+                if last.error is not None:
+                    _dump_story(self._story)
+            try:
+                _reset_tscat_backend(self.__class__.gui)
+            except Exception:
+                pass
+            settle()
+
+        class_dict["teardown"] = teardown
+
+        for action_fn in registry.actions:
+            meta: ActionMeta = action_fn._ui_meta
+            method_name = action_fn.__name__
+
+            rule_kwargs: dict[str, Any] = {}
+            if meta.target:
+                rule_kwargs["target"] = bundles_map[meta.target]
+
+            for param_name, bundle_name in (meta.bundles or {}).items():
+                rule_kwargs[param_name] = bundles_map[bundle_name]
+            for param_name, strategy in (meta.strategies or {}).items():
+                rule_kwargs[param_name] = strategy
+
+            def make_rule_method(fn, fn_meta):
+                def rule_method(self, **kwargs):
+                    return run_action(
+                        fn,
+                        self.__class__.gui,
+                        self._model,
+                        self._story,
+                        **kwargs,
+                    )
+
+                return rule_method
+
+            method = make_rule_method(action_fn, meta)
+            method.__name__ = method_name
+
+            if meta.precondition:
+                user_precond = meta.precondition
+                method = precondition(
+                    lambda self, _p=user_precond: _p(self._model)
+                )(method)
+
+            method = rule(**rule_kwargs)(method)
+            class_dict[method_name] = method
+
+        sm_class = type(name, (RuleBasedStateMachine,), class_dict)
+
+        sm_class.TestCase.settings = hypothesis_settings(
+            max_examples=max_examples,
+            stateful_step_count=stateful_step_count,
+            deadline=None,
+        )
+
+        return sm_class
+
+
+def _dump_story(story: Story):
+    import os
+    from datetime import datetime
+
+    narrative = story.narrative()
+    reproducer = story.reproducer()
+
+    print("\n=== FAILURE STORY ===")
+    print(narrative)
+    print("\n=== REPRODUCER ===")
+    print(reproducer)
+    print("=== END ===\n")
+
+    reports_dir = os.environ.get("TSCAT_TEST_REPORTS", "test-reports")
+    os.makedirs(reports_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    with open(os.path.join(reports_dir, f"story-{timestamp}.txt"), "w") as f:
+        f.write(narrative)
+    with open(os.path.join(reports_dir, f"story-{timestamp}.py"), "w") as f:
+        f.write(reproducer)

--- a/tests/fuzzing/attribute_actions.py
+++ b/tests/fuzzing/attribute_actions.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from tests.fuzzing.actions import ActionRegistry, settle, ui_action
+from tests.fuzzing.introspect import entity_attribute
+from tests.fuzzing.model import AppModel
+from tscat_gui import TSCatGUI
+from tscat_gui.undo import DeleteAttribute, NewAttribute, RenameAttribute, SetAttributeValue
+
+registry = ActionRegistry()
+
+
+@registry.register
+@ui_action(
+    narrate="Add attribute '{attr_name}' = {attr_value}",
+    model_update=lambda model, attr_name, attr_value: (
+        model.custom_attributes.update(
+            {
+                uuid: {**model.custom_attributes.get(uuid, {}), attr_name: attr_value}
+                for uuid in model.selected_catalogues + model.selected_events
+            }
+        ),
+    ),
+    verify=lambda gui, model, attr_name, attr_value: all(
+        entity_attribute(gui, uuid, attr_name) == attr_value
+        for uuid in model.selected_catalogues + model.selected_events
+    ),
+    precondition=lambda model: (
+        len(model.selected_catalogues) > 0 or len(model.selected_events) > 0
+    ),
+    settle_timeout_ms=500,
+)
+def add_custom_attribute(
+    gui: TSCatGUI,
+    model: AppModel,
+    attr_name: str = "test_attr",
+    attr_value: str = "test_value",
+):
+    gui.state.push_undo_command(NewAttribute, attr_name, attr_value)
+    settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Set attribute '{attr_name}' = {attr_value}",
+    model_update=lambda model, attr_name, attr_value: (
+        model.custom_attributes.update(
+            {
+                uuid: {**model.custom_attributes.get(uuid, {}), attr_name: attr_value}
+                for uuid in model.selected_catalogues + model.selected_events
+            }
+        ),
+    ),
+    verify=lambda gui, model, attr_name, attr_value: all(
+        entity_attribute(gui, uuid, attr_name) == attr_value
+        for uuid in model.selected_catalogues + model.selected_events
+    ),
+    precondition=lambda model: (
+        len(model.selected_catalogues) > 0 or len(model.selected_events) > 0
+    ),
+    settle_timeout_ms=500,
+)
+def set_attribute(
+    gui: TSCatGUI,
+    model: AppModel,
+    attr_name: str = "test_attr",
+    attr_value: str = "new_value",
+):
+    gui.state.push_undo_command(SetAttributeValue, attr_name, attr_value)
+    settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Rename attribute '{old_name}' -> '{new_name}'",
+    model_update=lambda model, old_name, new_name: (
+        model.custom_attributes.update(
+            {
+                uuid: {
+                    **(
+                        {k: v for k, v in model.custom_attributes.get(uuid, {}).items() if k != old_name}
+                    ),
+                    new_name: model.custom_attributes.get(uuid, {}).get(old_name),
+                }
+                for uuid in model.selected_catalogues + model.selected_events
+            }
+        ),
+    ),
+    verify=lambda gui, model, new_name: all(
+        entity_attribute(gui, uuid, new_name) is not None
+        for uuid in model.selected_catalogues + model.selected_events
+    ),
+    precondition=lambda model: (
+        len(model.selected_catalogues) > 0 or len(model.selected_events) > 0
+    ),
+    settle_timeout_ms=500,
+)
+def rename_attribute(
+    gui: TSCatGUI,
+    model: AppModel,
+    old_name: str = "test_attr",
+    new_name: str = "renamed_attr",
+):
+    gui.state.push_undo_command(RenameAttribute, old_name, new_name)
+    settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Delete attribute '{attr_name}'",
+    model_update=lambda model, attr_name: (
+        model.custom_attributes.update(
+            {
+                uuid: {
+                    k: v
+                    for k, v in model.custom_attributes.get(uuid, {}).items()
+                    if k != attr_name
+                }
+                for uuid in model.selected_catalogues + model.selected_events
+            }
+        ),
+    ),
+    verify=lambda gui, model, attr_name: all(
+        entity_attribute(gui, uuid, attr_name) is None
+        for uuid in model.selected_catalogues + model.selected_events
+    ),
+    precondition=lambda model: (
+        len(model.selected_catalogues) > 0 or len(model.selected_events) > 0
+    ),
+    settle_timeout_ms=500,
+)
+def delete_attribute(
+    gui: TSCatGUI,
+    model: AppModel,
+    attr_name: str = "test_attr",
+):
+    gui.state.push_undo_command(DeleteAttribute, attr_name)
+    settle(500)

--- a/tests/fuzzing/attribute_actions.py
+++ b/tests/fuzzing/attribute_actions.py
@@ -54,9 +54,7 @@ def add_custom_attribute(
         entity_attribute(gui, uuid, attr_name) == attr_value
         for uuid in model.selected_catalogues + model.selected_events
     ),
-    precondition=lambda model: (
-        len(model.selected_catalogues) > 0 or len(model.selected_events) > 0
-    ),
+    precondition=lambda model: model.selected_have_attribute,
     settle_timeout_ms=500,
 )
 def set_attribute(
@@ -89,9 +87,7 @@ def set_attribute(
         entity_attribute(gui, uuid, new_name) is not None
         for uuid in model.selected_catalogues + model.selected_events
     ),
-    precondition=lambda model: (
-        len(model.selected_catalogues) > 0 or len(model.selected_events) > 0
-    ),
+    precondition=lambda model: model.selected_have_attribute,
     settle_timeout_ms=500,
 )
 def rename_attribute(
@@ -123,9 +119,7 @@ def rename_attribute(
         entity_attribute(gui, uuid, attr_name) is None
         for uuid in model.selected_catalogues + model.selected_events
     ),
-    precondition=lambda model: (
-        len(model.selected_catalogues) > 0 or len(model.selected_events) > 0
-    ),
+    precondition=lambda model: model.selected_have_attribute,
     settle_timeout_ms=500,
 )
 def delete_attribute(

--- a/tests/fuzzing/attribute_actions.py
+++ b/tests/fuzzing/attribute_actions.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from tests.fuzzing.actions import ActionRegistry, settle, ui_action
+import datetime as dt
+
+from hypothesis import strategies as st
+
+from tests.fuzzing.actions import SKIP, ActionRegistry, settle, ui_action
 from tests.fuzzing.introspect import entity_attribute
 from tests.fuzzing.model import AppModel
 from tscat_gui import TSCatGUI
@@ -129,3 +133,65 @@ def delete_attribute(
 ):
     gui.state.push_undo_command(DeleteAttribute, attr_name)
     settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Edit catalogue name (idx={idx}) -> '{new_name}'",
+    strategies={
+        "idx": st.integers(min_value=0, max_value=999),
+        "new_name": st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N", "P", "Z")),
+            min_size=1,
+            max_size=30,
+        ),
+    },
+    model_update=lambda model, uuid, new_name: None,
+    verify=lambda gui, model, uuid, new_name: entity_attribute(gui, uuid, "name") == new_name,
+    precondition=lambda model: len([c for c in model.catalogues if c not in model.trashed]) > 0,
+    settle_timeout_ms=500,
+)
+def edit_catalogue_name(gui: TSCatGUI, model: AppModel, idx: int, new_name: str):
+    active = [c for c in model.catalogues if c not in model.trashed]
+    if not active:
+        return SKIP
+    uuid = active[idx % len(active)]
+    gui.state.updated("active_select", __import__("tscat")._Catalogue, [uuid])
+    settle(100)
+    gui.state.push_undo_command(SetAttributeValue, "name", new_name)
+    settle(500)
+    return {"uuid": uuid, "new_name": new_name}
+
+
+@registry.register
+@ui_action(
+    narrate="Edit event dates (idx={idx})",
+    strategies={
+        "idx": st.integers(min_value=0, max_value=999),
+        "offset_hours": st.integers(min_value=1, max_value=720),
+    },
+    model_update=lambda model, uuid, new_start, new_stop: None,
+    verify=lambda gui, model, uuid, new_start, new_stop: (
+        entity_attribute(gui, uuid, "start") == new_start
+        and entity_attribute(gui, uuid, "stop") == new_stop
+    ),
+    precondition=lambda model: model.has_events,
+    settle_timeout_ms=500,
+)
+def edit_event_dates(gui: TSCatGUI, model: AppModel, idx: int, offset_hours: int):
+    import tscat
+    all_events = [ev for evts in model.events.values() for ev in evts if ev not in model.trashed]
+    if not all_events:
+        return SKIP
+    uuid = all_events[idx % len(all_events)]
+
+    new_start = dt.datetime(2020, 1, 1) + dt.timedelta(hours=offset_hours)
+    new_stop = new_start + dt.timedelta(hours=1)
+
+    gui.state.updated("active_select", tscat._Event, [uuid])
+    settle(100)
+    gui.state.push_undo_command(SetAttributeValue, "start", new_start)
+    settle(300)
+    gui.state.push_undo_command(SetAttributeValue, "stop", new_stop)
+    settle(500)
+    return {"uuid": uuid, "new_start": new_start, "new_stop": new_stop}

--- a/tests/fuzzing/catalogue_actions.py
+++ b/tests/fuzzing/catalogue_actions.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from hypothesis import strategies as st
 from PySide6.QtCore import QItemSelectionModel
 
 import tscat
 
-from tests.fuzzing.actions import ActionRegistry, settle, ui_action
+from tests.fuzzing.actions import SKIP, ActionRegistry, settle, ui_action
 from tests.fuzzing.introspect import catalogue_uuids, selected_catalogue_uuids, trashed_uuids
 from tests.fuzzing.model import AppModel
 from tscat_gui import TSCatGUI
@@ -32,7 +33,6 @@ def _verify_trashed(gui: TSCatGUI, model: AppModel) -> None:
 
 @registry.register
 @ui_action(
-    target="catalogues",
     narrate="Create catalogue -> {result}",
     model_update=lambda model, result: (
         model.catalogues.append(result),
@@ -53,12 +53,19 @@ def create_catalogue(gui: TSCatGUI, model: AppModel):
 
 @registry.register
 @ui_action(
-    narrate="Select catalogue {uuid}",
+    narrate="Select catalogue (idx={idx})",
+    strategies={"idx": st.integers(min_value=0, max_value=999)},
+    precondition=lambda model: model.has_catalogues,
     model_update=lambda model, uuid: model.select_catalogue([uuid]),
     verify=lambda gui, model, uuid: uuid in selected_catalogue_uuids(gui),
     settle_timeout_ms=500,
+    manages_own_snapshots=True,
 )
-def select_catalogue(gui: TSCatGUI, model: AppModel, uuid: str):
+def select_catalogue(gui: TSCatGUI, model: AppModel, idx: int):
+    active = [u for u in model.catalogues if u not in model.trashed]
+    if not active:
+        return SKIP
+    uuid = active[idx % len(active)]
     source_index = gui.catalogue_model.index_from_uuid(uuid)
     proxy_index = gui.catalogue_sort_filter_model.mapFromSource(source_index)
     assert proxy_index.isValid(), f"Could not find proxy index for {uuid}"
@@ -66,51 +73,74 @@ def select_catalogue(gui: TSCatGUI, model: AppModel, uuid: str):
         proxy_index, QItemSelectionModel.SelectionFlag.ClearAndSelect
     )
     settle(500)
+    return {"uuid": uuid}
 
 
 @registry.register
 @ui_action(
-    narrate="Trash catalogue {uuid}",
-    model_update=lambda model, uuid: model.trashed.add(uuid),
+    narrate="Trash catalogue (idx={idx})",
+    strategies={"idx": st.integers(min_value=0, max_value=999)},
+    model_update=lambda model, uuid: (
+        model.trashed.add(uuid),
+        model.selected_catalogues.remove(uuid) if uuid in model.selected_catalogues else None,
+    ),
     verify=_verify_trashed,
     precondition=lambda model: model.has_catalogues,
     settle_timeout_ms=500,
 )
-def trash_catalogue(gui: TSCatGUI, model: AppModel, uuid: str):
+def trash_catalogue(gui: TSCatGUI, model: AppModel, idx: int):
+    active = [u for u in model.catalogues if u not in model.trashed]
+    if not active:
+        return SKIP
+    uuid = active[idx % len(active)]
     gui.state.updated("active_select", tscat._Catalogue, [uuid])
     settle(100)
     gui.state.push_undo_command(MoveEntityToTrash)
     settle(500)
+    return {"uuid": uuid}
 
 
 @registry.register
 @ui_action(
-    narrate="Restore catalogue {uuid}",
+    narrate="Restore catalogue (idx={idx})",
+    strategies={"idx": st.integers(min_value=0, max_value=999)},
     model_update=lambda model, uuid: model.trashed.discard(uuid),
     verify=_verify_catalogues,
     precondition=lambda model: model.has_trashed,
     settle_timeout_ms=500,
 )
-def restore_catalogue(gui: TSCatGUI, model: AppModel, uuid: str):
+def restore_catalogue(gui: TSCatGUI, model: AppModel, idx: int):
+    trashed_cats = [u for u in model.catalogues if u in model.trashed]
+    if not trashed_cats:
+        return SKIP
+    uuid = trashed_cats[idx % len(trashed_cats)]
     gui.state.updated("active_select", tscat._Catalogue, [uuid])
     settle(100)
     gui.state.push_undo_command(RestoreEntityFromTrash)
     settle(500)
+    return {"uuid": uuid}
 
 
 @registry.register
 @ui_action(
-    narrate="Delete catalogue {uuid} permanently",
+    narrate="Delete catalogue permanently (idx={idx})",
+    strategies={"idx": st.integers(min_value=0, max_value=999)},
     model_update=lambda model, uuid: (
         model.catalogues.remove(uuid),
         model.trashed.discard(uuid),
+        model.selected_catalogues.remove(uuid) if uuid in model.selected_catalogues else None,
     ),
     verify=_verify_catalogues,
     precondition=lambda model: model.has_trashed,
     settle_timeout_ms=500,
 )
-def delete_permanently(gui: TSCatGUI, model: AppModel, uuid: str):
+def delete_permanently(gui: TSCatGUI, model: AppModel, idx: int):
+    trashed_cats = [u for u in model.catalogues if u in model.trashed]
+    if not trashed_cats:
+        return SKIP
+    uuid = trashed_cats[idx % len(trashed_cats)]
     gui.state.updated("active_select", tscat._Catalogue, [uuid])
     settle(100)
     gui.state.push_undo_command(DeletePermanently)
     settle(500)
+    return {"uuid": uuid}

--- a/tests/fuzzing/catalogue_actions.py
+++ b/tests/fuzzing/catalogue_actions.py
@@ -76,14 +76,16 @@ def select_catalogue(gui: TSCatGUI, model: AppModel, idx: int):
     return {"uuid": uuid}
 
 
+def _model_trash_catalogue(model: AppModel, uuid: str) -> None:
+    model.trashed.add(uuid)
+    model.select_catalogue([uuid])
+
+
 @registry.register
 @ui_action(
     narrate="Trash catalogue (idx={idx})",
     strategies={"idx": st.integers(min_value=0, max_value=999)},
-    model_update=lambda model, uuid: (
-        model.trashed.add(uuid),
-        model.selected_catalogues.remove(uuid) if uuid in model.selected_catalogues else None,
-    ),
+    model_update=_model_trash_catalogue,
     verify=_verify_trashed,
     precondition=lambda model: model.has_catalogues,
     settle_timeout_ms=500,
@@ -121,15 +123,18 @@ def restore_catalogue(gui: TSCatGUI, model: AppModel, idx: int):
     return {"uuid": uuid}
 
 
+def _model_delete_permanently(model: AppModel, uuid: str) -> None:
+    model.catalogues.remove(uuid)
+    model.trashed.discard(uuid)
+    model.events.pop(uuid, None)
+    model.select_catalogue([])
+
+
 @registry.register
 @ui_action(
     narrate="Delete catalogue permanently (idx={idx})",
     strategies={"idx": st.integers(min_value=0, max_value=999)},
-    model_update=lambda model, uuid: (
-        model.catalogues.remove(uuid),
-        model.trashed.discard(uuid),
-        model.selected_catalogues.remove(uuid) if uuid in model.selected_catalogues else None,
-    ),
+    model_update=_model_delete_permanently,
     verify=_verify_catalogues,
     precondition=lambda model: model.has_trashed,
     settle_timeout_ms=500,

--- a/tests/fuzzing/catalogue_actions.py
+++ b/tests/fuzzing/catalogue_actions.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QItemSelectionModel
+
+import tscat
+
+from tests.fuzzing.actions import ActionRegistry, settle, ui_action
+from tests.fuzzing.introspect import catalogue_uuids, selected_catalogue_uuids, trashed_uuids
+from tests.fuzzing.model import AppModel
+from tscat_gui import TSCatGUI
+from tscat_gui.undo import (
+    DeletePermanently,
+    MoveEntityToTrash,
+    NewCatalogue,
+    RestoreEntityFromTrash,
+)
+
+registry = ActionRegistry()
+
+
+def _verify_catalogues(gui: TSCatGUI, model: AppModel) -> None:
+    live = set(catalogue_uuids(gui))
+    expected = {u for u in model.catalogues if u not in model.trashed}
+    assert live == expected, f"catalogues mismatch: live={live}, expected={expected}"
+
+
+def _verify_trashed(gui: TSCatGUI, model: AppModel) -> None:
+    live = trashed_uuids(gui)
+    expected = model.trashed & set(model.catalogues)
+    assert live == expected, f"trashed mismatch: live={live}, expected={expected}"
+
+
+@registry.register
+@ui_action(
+    target="catalogues",
+    narrate="Create catalogue -> {result}",
+    model_update=lambda model, result: (
+        model.catalogues.append(result),
+        model.select_catalogue([result]),
+    ),
+    verify=_verify_catalogues,
+    settle_timeout_ms=500,
+)
+def create_catalogue(gui: TSCatGUI, model: AppModel):
+    before = set(catalogue_uuids(gui))
+    gui.state.push_undo_command(NewCatalogue)
+    settle(500)
+    after = set(catalogue_uuids(gui))
+    new = after - before
+    assert len(new) == 1, f"Expected 1 new catalogue, got {len(new)}"
+    return new.pop()
+
+
+@registry.register
+@ui_action(
+    narrate="Select catalogue {uuid}",
+    model_update=lambda model, uuid: model.select_catalogue([uuid]),
+    verify=lambda gui, model, uuid: uuid in selected_catalogue_uuids(gui),
+    settle_timeout_ms=500,
+)
+def select_catalogue(gui: TSCatGUI, model: AppModel, uuid: str):
+    source_index = gui.catalogue_model.index_from_uuid(uuid)
+    proxy_index = gui.catalogue_sort_filter_model.mapFromSource(source_index)
+    assert proxy_index.isValid(), f"Could not find proxy index for {uuid}"
+    gui.catalogues_view.selectionModel().select(
+        proxy_index, QItemSelectionModel.SelectionFlag.ClearAndSelect
+    )
+    settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Trash catalogue {uuid}",
+    model_update=lambda model, uuid: model.trashed.add(uuid),
+    verify=_verify_trashed,
+    precondition=lambda model: model.has_catalogues,
+    settle_timeout_ms=500,
+)
+def trash_catalogue(gui: TSCatGUI, model: AppModel, uuid: str):
+    gui.state.updated("active_select", tscat._Catalogue, [uuid])
+    settle(100)
+    gui.state.push_undo_command(MoveEntityToTrash)
+    settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Restore catalogue {uuid}",
+    model_update=lambda model, uuid: model.trashed.discard(uuid),
+    verify=_verify_catalogues,
+    precondition=lambda model: model.has_trashed,
+    settle_timeout_ms=500,
+)
+def restore_catalogue(gui: TSCatGUI, model: AppModel, uuid: str):
+    gui.state.updated("active_select", tscat._Catalogue, [uuid])
+    settle(100)
+    gui.state.push_undo_command(RestoreEntityFromTrash)
+    settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Delete catalogue {uuid} permanently",
+    model_update=lambda model, uuid: (
+        model.catalogues.remove(uuid),
+        model.trashed.discard(uuid),
+    ),
+    verify=_verify_catalogues,
+    precondition=lambda model: model.has_trashed,
+    settle_timeout_ms=500,
+)
+def delete_permanently(gui: TSCatGUI, model: AppModel, uuid: str):
+    gui.state.updated("active_select", tscat._Catalogue, [uuid])
+    settle(100)
+    gui.state.push_undo_command(DeletePermanently)
+    settle(500)

--- a/tests/fuzzing/conftest.py
+++ b/tests/fuzzing/conftest.py
@@ -1,0 +1,41 @@
+import os
+
+import pytest
+
+import tscat.base as _tscat_base
+from tscat_gui import TSCatGUI
+from tscat_gui.tscat_driver.driver import tscat_driver
+from tests.fuzzing.actions import StoryRunner
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _verify_temp_db():
+    """Safety guard: abort if the tscat backend is not using a temp database."""
+    backend = _tscat_base._backend
+    db_url = str(backend.engine.url)
+    assert "tmp" in db_url or "test" in db_url, \
+        f"SAFETY: fuzzing tests must run against a temp database, not real catalogues! (url={db_url})"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fuzzing_reports_dir():
+    """Ensure test-reports directory exists for story dumps."""
+    reports_dir = os.environ.get("TSCAT_TEST_REPORTS", "test-reports")
+    os.makedirs(reports_dir, exist_ok=True)
+
+
+@pytest.fixture
+def gui(qtbot):
+    """A TSCatGUI widget with test isolation."""
+    widget = TSCatGUI()
+    qtbot.addWidget(widget)
+    yield widget
+    tscat_driver.setParent(None)
+
+
+@pytest.fixture
+def story_runner(gui):
+    """A StoryRunner wired to the live gui, with automatic cleanup."""
+    runner = StoryRunner(gui)
+    yield runner
+    runner.cleanup()

--- a/tests/fuzzing/event_actions.py
+++ b/tests/fuzzing/event_actions.py
@@ -74,7 +74,8 @@ def add_event_to_catalogue(gui: TSCatGUI, model: AppModel, eidx: int, cidx: int)
     strategies={"idx": st.integers(min_value=0, max_value=999)},
     model_update=lambda model, uuid: (
         model.trashed.add(uuid),
-        model.selected_events.remove(uuid) if uuid in model.selected_events else None,
+        model.selected_events.clear(),
+        model.selected_events.append(uuid),
     ),
     verify=_verify_event_count,
     precondition=lambda model: model.has_events,

--- a/tests/fuzzing/event_actions.py
+++ b/tests/fuzzing/event_actions.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import tscat
+
+from tests.fuzzing.actions import ActionRegistry, settle, ui_action
+from tests.fuzzing.introspect import selected_event_uuids, visible_event_count
+from tests.fuzzing.model import AppModel
+from tscat_gui import TSCatGUI
+from tscat_gui.undo import AddEventsToCatalogue, MoveEntityToTrash, NewEvent
+
+registry = ActionRegistry()
+
+
+def _verify_event_count(gui: TSCatGUI, model: AppModel) -> None:
+    expected = len(model.active_events)
+    live = visible_event_count(gui)
+    assert live == expected, f"event count mismatch: live={live}, expected={expected}"
+
+
+@registry.register
+@ui_action(
+    target="events",
+    narrate="Create event -> {result}",
+    model_update=lambda model, result: (
+        model.events.setdefault(model.selected_catalogues[0], []).append(result),
+    ),
+    verify=_verify_event_count,
+    precondition=lambda model: (
+        len(model.selected_catalogues) == 1
+        and model.selected_catalogues[0] not in model.trashed
+    ),
+    settle_timeout_ms=500,
+)
+def create_event(gui: TSCatGUI, model: AppModel):
+    gui.state.push_undo_command(NewEvent)
+    settle(500)
+    uuids = selected_event_uuids(gui)
+    assert len(uuids) >= 1, f"Expected at least 1 selected event, got {len(uuids)}"
+    return uuids[-1]
+
+
+@registry.register
+@ui_action(
+    narrate="Add events {event_uuids} to catalogue {catalogue_uuid}",
+    model_update=lambda model, event_uuids, catalogue_uuid: (
+        model.events.setdefault(catalogue_uuid, []).extend(event_uuids),
+    ),
+    verify=lambda gui, model: True,
+    precondition=lambda model: model.has_events and len(model.catalogues) > 1,
+    settle_timeout_ms=500,
+)
+def add_event_to_catalogue(
+    gui: TSCatGUI, model: AppModel, event_uuids: list[str], catalogue_uuid: str
+):
+    gui.state.push_undo_command(AddEventsToCatalogue, catalogue_uuid, event_uuids)
+    settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Trash event {uuid}",
+    model_update=lambda model, uuid: model.trashed.add(uuid),
+    verify=_verify_event_count,
+    precondition=lambda model: model.has_events,
+    settle_timeout_ms=500,
+)
+def trash_event(gui: TSCatGUI, model: AppModel, uuid: str):
+    gui.state.updated("active_select", tscat._Event, [uuid])
+    settle(100)
+    gui.state.push_undo_command(MoveEntityToTrash)
+    settle(500)

--- a/tests/fuzzing/event_actions.py
+++ b/tests/fuzzing/event_actions.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from hypothesis import strategies as st
+
 import tscat
 
-from tests.fuzzing.actions import ActionRegistry, settle, ui_action
+from tests.fuzzing.actions import SKIP, ActionRegistry, settle, ui_action
 from tests.fuzzing.introspect import selected_event_uuids, visible_event_count
 from tests.fuzzing.model import AppModel
 from tscat_gui import TSCatGUI
@@ -17,13 +19,15 @@ def _verify_event_count(gui: TSCatGUI, model: AppModel) -> None:
     assert live == expected, f"event count mismatch: live={live}, expected={expected}"
 
 
+def _model_create_event(model: AppModel, result: str) -> None:
+    model.events.setdefault(model.selected_catalogues[0], []).append(result)
+    model.selected_events = [result]
+
+
 @registry.register
 @ui_action(
-    target="events",
     narrate="Create event -> {result}",
-    model_update=lambda model, result: (
-        model.events.setdefault(model.selected_catalogues[0], []).append(result),
-    ),
+    model_update=_model_create_event,
     verify=_verify_event_count,
     precondition=lambda model: (
         len(model.selected_catalogues) == 1
@@ -41,31 +45,48 @@ def create_event(gui: TSCatGUI, model: AppModel):
 
 @registry.register
 @ui_action(
-    narrate="Add events {event_uuids} to catalogue {catalogue_uuid}",
-    model_update=lambda model, event_uuids, catalogue_uuid: (
-        model.events.setdefault(catalogue_uuid, []).extend(event_uuids),
+    narrate="Add event (eidx={eidx}) to catalogue (cidx={cidx})",
+    strategies={
+        "eidx": st.integers(min_value=0, max_value=999),
+        "cidx": st.integers(min_value=0, max_value=999),
+    },
+    model_update=lambda model, event_uuid, catalogue_uuid: (
+        model.events.setdefault(catalogue_uuid, []).append(event_uuid),
     ),
     verify=lambda gui, model: True,
     precondition=lambda model: model.has_events and len(model.catalogues) > 1,
     settle_timeout_ms=500,
 )
-def add_event_to_catalogue(
-    gui: TSCatGUI, model: AppModel, event_uuids: list[str], catalogue_uuid: str
-):
-    gui.state.push_undo_command(AddEventsToCatalogue, catalogue_uuid, event_uuids)
+def add_event_to_catalogue(gui: TSCatGUI, model: AppModel, eidx: int, cidx: int):
+    all_events = [ev for evts in model.events.values() for ev in evts]
+    if not all_events:
+        return SKIP
+    event_uuid = all_events[eidx % len(all_events)]
+    catalogue_uuid = model.catalogues[cidx % len(model.catalogues)]
+    gui.state.push_undo_command(AddEventsToCatalogue, catalogue_uuid, [event_uuid])
     settle(500)
+    return {"event_uuid": event_uuid, "catalogue_uuid": catalogue_uuid}
 
 
 @registry.register
 @ui_action(
-    narrate="Trash event {uuid}",
-    model_update=lambda model, uuid: model.trashed.add(uuid),
+    narrate="Trash event (idx={idx})",
+    strategies={"idx": st.integers(min_value=0, max_value=999)},
+    model_update=lambda model, uuid: (
+        model.trashed.add(uuid),
+        model.selected_events.remove(uuid) if uuid in model.selected_events else None,
+    ),
     verify=_verify_event_count,
     precondition=lambda model: model.has_events,
     settle_timeout_ms=500,
 )
-def trash_event(gui: TSCatGUI, model: AppModel, uuid: str):
+def trash_event(gui: TSCatGUI, model: AppModel, idx: int):
+    all_events = [ev for evts in model.events.values() for ev in evts if ev not in model.trashed]
+    if not all_events:
+        return SKIP
+    uuid = all_events[idx % len(all_events)]
     gui.state.updated("active_select", tscat._Event, [uuid])
     settle(100)
     gui.state.push_undo_command(MoveEntityToTrash)
     settle(500)
+    return {"uuid": uuid}

--- a/tests/fuzzing/introspect.py
+++ b/tests/fuzzing/introspect.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtCore import QModelIndex
+
+from tscat_gui import TSCatGUI
+from tscat_gui.tscat_driver.driver import tscat_driver
+from tscat_gui.tscat_driver.nodes import CatalogNode, FolderNode, TrashNode
+from tscat_gui.model_base.constants import UUIDDataRole
+
+
+def _walk_tree(gui: TSCatGUI):
+    """Yield all (node, is_in_trash) pairs from the root model."""
+    model = gui.catalogues_view.model()
+    source = model.sourceModel() if hasattr(model, 'sourceModel') else model
+
+    def _recurse(parent_index, in_trash=False):
+        for row in range(source.rowCount(parent_index)):
+            index = source.index(row, 0, parent_index)
+            node = index.internalPointer()
+            child_in_trash = in_trash or isinstance(node, TrashNode)
+            yield node, child_in_trash
+            yield from _recurse(index, child_in_trash)
+
+    yield from _recurse(QModelIndex())
+
+
+def catalogue_uuids(gui: TSCatGUI) -> list[str]:
+    return [n.uuid for n, in_trash in _walk_tree(gui)
+            if isinstance(n, CatalogNode) and not in_trash]
+
+
+def trashed_uuids(gui: TSCatGUI) -> set[str]:
+    return {n.uuid for n, in_trash in _walk_tree(gui)
+            if isinstance(n, CatalogNode) and in_trash}
+
+
+def folder_paths(gui: TSCatGUI) -> list[str]:
+    return ["/".join(n.full_path()) for n, _ in _walk_tree(gui)
+            if isinstance(n, FolderNode)]
+
+
+def selected_catalogue_uuids(gui: TSCatGUI) -> list[str]:
+    indexes = gui.catalogues_view.selectionModel().selectedIndexes()
+    result = []
+    for idx in indexes:
+        uuid = idx.data(UUIDDataRole)
+        if uuid is not None:
+            result.append(uuid)
+    return result
+
+
+def selected_event_uuids(gui: TSCatGUI) -> list[str]:
+    indexes = gui.events_view.selectionModel().selectedIndexes()
+    seen: set[str] = set()
+    result: list[str] = []
+    for idx in indexes:
+        uuid = idx.data(UUIDDataRole)
+        if uuid is not None and uuid not in seen:
+            seen.add(uuid)
+            result.append(uuid)
+    return result
+
+
+def entity_attribute(gui: TSCatGUI, uuid: str, attr_name: str) -> Any:
+    entity = tscat_driver.entity_from_uuid(uuid)
+    if entity is None:
+        return None
+    return getattr(entity, attr_name, None)
+
+
+def undo_index(gui: TSCatGUI) -> int:
+    return gui.state.undo_stack().index()
+
+
+def visible_event_count(gui: TSCatGUI) -> int:
+    return gui.event_model.rowCount()

--- a/tests/fuzzing/model.py
+++ b/tests/fuzzing/model.py
@@ -39,6 +39,18 @@ class AppModel:
         return len(self._redo_stack) > 0
 
     @property
+    def has_selection(self) -> bool:
+        return len(self.selected_catalogues) > 0 or len(self.selected_events) > 0
+
+    @property
+    def selected_have_attribute(self) -> bool:
+        selected = self.selected_catalogues + self.selected_events
+        return any(
+            len(self.custom_attributes.get(uuid, {})) > 0
+            for uuid in selected
+        )
+
+    @property
     def active_events(self) -> list[str]:
         result = []
         for cat in self.selected_catalogues:

--- a/tests/fuzzing/model.py
+++ b/tests/fuzzing/model.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class AppModel:
+    catalogues: list[str] = field(default_factory=list)
+    events: dict[str, list[str]] = field(default_factory=dict)
+    folders: list[str] = field(default_factory=list)
+    trashed: set[str] = field(default_factory=set)
+    custom_attributes: dict[str, dict[str, Any]] = field(default_factory=dict)
+    selected_catalogues: list[str] = field(default_factory=list)
+    selected_events: list[str] = field(default_factory=list)
+    undo_depth: int = 0
+    _snapshots: list[AppModel] = field(default_factory=list)
+    _redo_stack: list[AppModel] = field(default_factory=list)
+
+    @property
+    def has_catalogues(self) -> bool:
+        return len(self.catalogues) > 0
+
+    @property
+    def has_events(self) -> bool:
+        return any(len(evts) > 0 for evts in self.events.values())
+
+    @property
+    def has_trashed(self) -> bool:
+        return len(self.trashed) > 0
+
+    @property
+    def has_undo(self) -> bool:
+        return len(self._snapshots) > 0
+
+    @property
+    def has_redo(self) -> bool:
+        return len(self._redo_stack) > 0
+
+    @property
+    def active_events(self) -> list[str]:
+        result = []
+        for cat in self.selected_catalogues:
+            for ev in self.events.get(cat, []):
+                if ev not in self.trashed:
+                    result.append(ev)
+        return result
+
+    def select_catalogue(self, uuids: list[str]) -> None:
+        self.selected_catalogues = uuids
+        self.selected_events = []
+
+    def _state_snapshot(self) -> AppModel:
+        return AppModel(
+            catalogues=list(self.catalogues),
+            events={k: list(v) for k, v in self.events.items()},
+            folders=list(self.folders),
+            trashed=set(self.trashed),
+            custom_attributes=deepcopy(self.custom_attributes),
+            selected_catalogues=list(self.selected_catalogues),
+            selected_events=list(self.selected_events),
+            undo_depth=self.undo_depth,
+        )
+
+    def _restore_from(self, snap: AppModel) -> None:
+        self.catalogues = snap.catalogues
+        self.events = snap.events
+        self.folders = snap.folders
+        self.trashed = snap.trashed
+        self.custom_attributes = snap.custom_attributes
+        self.selected_catalogues = snap.selected_catalogues
+        self.selected_events = snap.selected_events
+        self.undo_depth = snap.undo_depth
+
+    def push_snapshot(self) -> None:
+        self._snapshots.append(self._state_snapshot())
+        self._redo_stack.clear()
+
+    def pop_snapshot(self) -> None:
+        if not self._snapshots:
+            raise IndexError("No snapshots to pop")
+        self._redo_stack.append(self._state_snapshot())
+        self._restore_from(self._snapshots.pop())
+
+    def pop_redo(self) -> None:
+        if not self._redo_stack:
+            raise IndexError("No redo snapshots")
+        self._snapshots.append(self._state_snapshot())
+        self._restore_from(self._redo_stack.pop())
+
+    def reset(self) -> None:
+        self.catalogues.clear()
+        self.events.clear()
+        self.folders.clear()
+        self.trashed.clear()
+        self.custom_attributes.clear()
+        self.selected_catalogues.clear()
+        self.selected_events.clear()
+        self.undo_depth = 0
+        self._snapshots.clear()
+        self._redo_stack.clear()

--- a/tests/fuzzing/story.py
+++ b/tests/fuzzing/story.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from textwrap import indent
+from typing import Any
+
+
+@dataclass
+class Step:
+    action_name: str
+    args: dict[str, str]
+    narrate_template: str
+    result: Any = None
+    error: Exception | None = None
+
+    @property
+    def narrative(self) -> str:
+        fmt_kwargs = {**self.args}
+        if self.result is not None:
+            fmt_kwargs["result"] = self.result
+        return self.narrate_template.format(**fmt_kwargs)
+
+    def as_code(self) -> str:
+        args_str = ", ".join(f"{k}={v!r}" for k, v in self.args.items())
+        return f"actions.{self.action_name}({args_str})"
+
+
+class Story:
+    def __init__(self):
+        self.steps: list[Step] = []
+
+    def record(self, step: Step):
+        self.steps.append(step)
+
+    def narrative(self) -> str:
+        return "\n".join(
+            f"{i + 1}. {step.narrative}" for i, step in enumerate(self.steps)
+        )
+
+    def reproducer(self) -> str:
+        lines = [step.as_code() for step in self.steps]
+        body = indent("\n".join(lines), "    ") if lines else "    pass"
+        return f"def test_reproducer(gui, qtbot):\n{body}"

--- a/tests/fuzzing/story.py
+++ b/tests/fuzzing/story.py
@@ -18,7 +18,10 @@ class Step:
         fmt_kwargs = {**self.args}
         if self.result is not None:
             fmt_kwargs["result"] = self.result
-        return self.narrate_template.format(**fmt_kwargs)
+        try:
+            return self.narrate_template.format(**fmt_kwargs)
+        except KeyError:
+            return f"{self.action_name}({self.args})"
 
     def as_code(self) -> str:
         args_str = ", ".join(f"{k}={v!r}" for k, v in self.args.items())

--- a/tests/fuzzing/test_actions.py
+++ b/tests/fuzzing/test_actions.py
@@ -1,0 +1,177 @@
+import inspect
+
+import pytest
+
+from tests.fuzzing.actions import ui_action, ActionRegistry, StoryRunner
+from tests.fuzzing.model import AppModel
+
+
+def test_ui_action_stores_metadata():
+    @ui_action(
+        narrate="Did something",
+        model_update=lambda model: None,
+        verify=lambda gui, model: True,
+    )
+    def my_action(gui, model):
+        return "ok"
+
+    assert my_action._ui_meta.narrate == "Did something"
+    assert my_action._ui_meta.precondition is None
+    assert my_action._ui_meta.manages_own_snapshots is False
+
+
+def test_ui_action_with_precondition():
+    @ui_action(
+        narrate="X",
+        model_update=lambda model: None,
+        verify=lambda gui, model: True,
+        precondition=lambda model: model.has_catalogues,
+    )
+    def guarded(gui, model):
+        pass
+
+    assert guarded._ui_meta.precondition is not None
+    model = AppModel()
+    assert not guarded._ui_meta.precondition(model)
+    model.catalogues.append("C")
+    assert guarded._ui_meta.precondition(model)
+
+
+def test_ui_action_with_target():
+    @ui_action(
+        target="catalogues",
+        narrate="Created '{result}'",
+        model_update=lambda model, result: model.catalogues.append(result),
+        verify=lambda gui, model: True,
+    )
+    def create(gui, model):
+        return "cat-1"
+
+    assert create._ui_meta.target == "catalogues"
+
+
+def test_ui_action_manages_own_snapshots():
+    @ui_action(
+        narrate="Undo",
+        model_update=lambda model: None,
+        verify=lambda gui, model: True,
+        manages_own_snapshots=True,
+    )
+    def undo(gui, model):
+        pass
+
+    assert undo._ui_meta.manages_own_snapshots is True
+
+
+def test_registry_collects_actions():
+    registry = ActionRegistry()
+
+    @registry.register
+    @ui_action(
+        narrate="A", model_update=lambda model: None, verify=lambda gui, model: True
+    )
+    def action_a(gui, model):
+        pass
+
+    @registry.register
+    @ui_action(
+        narrate="B", model_update=lambda model: None, verify=lambda gui, model: True
+    )
+    def action_b(gui, model):
+        pass
+
+    assert len(registry.actions) == 2
+    assert registry.actions[0].__name__ == "action_a"
+
+
+def test_callback_binding_introspects_signature():
+    received = {}
+
+    def capture_update(model, result):
+        received["model"] = model
+        received["result"] = result
+
+    @ui_action(
+        narrate="",
+        model_update=capture_update,
+        verify=lambda gui, model: True,
+    )
+    def act(gui, model):
+        return "val"
+
+    meta = act._ui_meta
+    kwargs = {"result": "val", "extra": "ignored"}
+    params = set(inspect.signature(meta.model_update).parameters.keys())
+    bound = {k: v for k, v in kwargs.items() if k in params}
+    meta.model_update(model=AppModel(), **bound)
+    assert received["result"] == "val"
+    assert "extra" not in received
+
+
+class _FakeGui:
+    pass
+
+
+def test_story_runner_records_steps():
+    @ui_action(
+        target="catalogues",
+        narrate="Created catalogue '{result}'",
+        model_update=lambda model, result: model.catalogues.append(result),
+        verify=lambda gui, model: True,
+    )
+    def create(gui, model):
+        return "cat-1"
+
+    runner = StoryRunner(_FakeGui())
+    result = runner.run(create)
+
+    assert result == "cat-1"
+    assert runner.model.catalogues == ["cat-1"]
+    assert len(runner.story.steps) == 1
+    assert "cat-1" in runner.story.steps[0].narrative
+
+
+def test_story_runner_dumps_on_failure():
+    @ui_action(
+        narrate="Boom",
+        model_update=lambda model: None,
+        verify=lambda gui, model: False,
+    )
+    def failing(gui, model):
+        return None
+
+    runner = StoryRunner(_FakeGui())
+    with pytest.raises(AssertionError, match="Verification failed"):
+        runner.run(failing)
+
+    assert len(runner.story.steps) == 1
+    assert runner.story.steps[0].error is not None
+
+
+def test_run_action_pushes_snapshot_for_normal_actions():
+    @ui_action(
+        narrate="Normal",
+        model_update=lambda model: None,
+        verify=lambda gui, model: True,
+    )
+    def normal(gui, model):
+        return None
+
+    runner = StoryRunner(_FakeGui())
+    runner.run(normal)
+    assert len(runner.model._snapshots) == 1
+
+
+def test_run_action_skips_snapshot_for_manages_own():
+    @ui_action(
+        narrate="Self-managed",
+        model_update=lambda model: None,
+        verify=lambda gui, model: True,
+        manages_own_snapshots=True,
+    )
+    def self_managed(gui, model):
+        return None
+
+    runner = StoryRunner(_FakeGui())
+    runner.run(self_managed)
+    assert len(runner.model._snapshots) == 0

--- a/tests/fuzzing/test_fuzzer_regressions.py
+++ b/tests/fuzzing/test_fuzzer_regressions.py
@@ -37,3 +37,36 @@ def test_new_event_redo_with_empty_selected_catalogues(story_runner):
     # _redo should not crash — it should gracefully skip
     cmd._redo()
     settle(200)
+
+
+def test_event_count_after_undo_catalogue_creation(gui):
+    """Bug: passive_select didn't update selected_catalogues in AppState.
+
+    Sequence: create_event -> create_catalogue -> undo -> create_event
+    After undoing a catalogue creation, the undo command restores event
+    selection via passive_select (catalogue) + active_select (event).
+    But passive_select didn't update selected_catalogues, so the state
+    still pointed to the deleted catalogue's UUID. The next NewEvent
+    would then try to add an event to a non-existent catalogue.
+    """
+    from tests.fuzzing.introspect import visible_event_count
+    from tscat_gui.undo import NewCatalogue, NewEvent
+
+    gui.state.push_undo_command(NewCatalogue)
+    settle(500)
+
+    gui.state.push_undo_command(NewEvent)
+    settle(500)
+    assert visible_event_count(gui) == 1
+
+    gui.state.push_undo_command(NewCatalogue)
+    settle(500)
+    assert visible_event_count(gui) == 0
+
+    gui.state.undo_stack().undo()
+    settle(500)
+    assert visible_event_count(gui) == 1
+
+    gui.state.push_undo_command(NewEvent)
+    settle(500)
+    assert visible_event_count(gui) == 2

--- a/tests/fuzzing/test_fuzzer_regressions.py
+++ b/tests/fuzzing/test_fuzzer_regressions.py
@@ -1,0 +1,39 @@
+"""Regression tests for bugs found by the story-driven UI fuzzer.
+
+Each test reproduces a specific bug. The test must fail before the fix
+and pass after.
+"""
+from tests.fuzzing.actions import settle
+
+
+def test_entity_from_uuid_returns_none_for_missing(story_runner):
+    """Bug: entity_from_uuid raises KeyError for UUIDs not in cache.
+
+    During rapid undo/redo sequences the driver's entity cache can be
+    out of sync with signal handlers referencing stale UUIDs. The method
+    must return None instead of crashing.
+    """
+    from tscat_gui.tscat_driver.driver import tscat_driver
+
+    bogus_uuid = "00000000-dead-beef-0000-000000000000"
+    result = tscat_driver.entity_from_uuid(bogus_uuid)
+    assert result is None
+
+
+def test_new_event_redo_with_empty_selected_catalogues(story_runner):
+    """Bug: NewEvent._redo() crashes with IndexError on selected_catalogues[0].
+
+    When NewEvent is created with no catalogue selected (empty selected_catalogues
+    in the captured state), _redo() must not crash.
+    """
+    from tscat_gui.undo import NewEvent
+    from tscat_gui.state import AppState
+
+    state = AppState()
+    # Don't select any catalogue — selected_catalogues is []
+    cmd = NewEvent(state)
+    assert state.select_state().selected_catalogues == []
+
+    # _redo should not crash — it should gracefully skip
+    cmd._redo()
+    settle(200)

--- a/tests/fuzzing/test_model.py
+++ b/tests/fuzzing/test_model.py
@@ -1,0 +1,103 @@
+from tests.fuzzing.model import AppModel
+
+
+def test_fresh_model_is_empty():
+    model = AppModel()
+    assert not model.has_catalogues
+    assert not model.has_events
+    assert not model.has_trashed
+    assert not model.has_undo
+    assert model.events == {}
+    assert model.custom_attributes == {}
+
+
+def test_add_catalogue():
+    model = AppModel()
+    model.catalogues.append("cat-1")
+    assert model.has_catalogues
+    assert len(model.catalogues) == 1
+
+
+def test_add_event():
+    model = AppModel()
+    model.catalogues.append("cat-1")
+    model.events.setdefault("cat-1", []).append("ev-1")
+    assert model.has_events
+
+
+def test_trash_and_has_trashed():
+    model = AppModel()
+    model.trashed.add("cat-1")
+    assert model.has_trashed
+
+
+def test_active_events_returns_events_in_selected_catalogues():
+    model = AppModel()
+    model.catalogues.extend(["cat-1", "cat-2"])
+    model.events["cat-1"] = ["ev-1", "ev-2"]
+    model.events["cat-2"] = ["ev-3"]
+    model.selected_catalogues = ["cat-1"]
+    assert model.active_events == ["ev-1", "ev-2"]
+
+
+def test_active_events_excludes_trashed():
+    model = AppModel()
+    model.catalogues.append("cat-1")
+    model.events["cat-1"] = ["ev-1", "ev-2"]
+    model.trashed.add("ev-1")
+    model.selected_catalogues = ["cat-1"]
+    assert model.active_events == ["ev-2"]
+
+
+def test_select_catalogue_clears_selected_events():
+    model = AppModel()
+    model.selected_events = ["ev-1"]
+    model.select_catalogue(["cat-1"])
+    assert model.selected_catalogues == ["cat-1"]
+    assert model.selected_events == []
+
+
+def test_snapshot_and_restore():
+    model = AppModel()
+    model.catalogues.append("cat-1")
+    model.push_snapshot()
+    model.catalogues.append("cat-2")
+    assert len(model.catalogues) == 2
+    model.pop_snapshot()
+    assert model.catalogues == ["cat-1"]
+    assert len(model._redo_stack) == 1
+
+
+def test_new_action_clears_redo_stack():
+    model = AppModel()
+    model.push_snapshot()
+    model.catalogues.append("cat-1")
+    model.pop_snapshot()
+    assert len(model._redo_stack) == 1
+    model.push_snapshot()
+    assert len(model._redo_stack) == 0
+
+
+def test_redo_after_undo():
+    model = AppModel()
+    model.catalogues.append("cat-1")
+    model.push_snapshot()
+    model.catalogues.append("cat-2")
+    model.pop_snapshot()
+    assert model.catalogues == ["cat-1"]
+    model.pop_redo()
+    assert model.catalogues == ["cat-1", "cat-2"]
+
+
+def test_reset_clears_everything():
+    model = AppModel()
+    model.catalogues.extend(["a", "b"])
+    model.events["a"] = ["x"]
+    model.trashed.add("z")
+    model.push_snapshot()
+    model.reset()
+    assert not model.has_catalogues
+    assert model.events == {}
+    assert not model.has_trashed
+    assert len(model._snapshots) == 0
+    assert len(model._redo_stack) == 0

--- a/tests/fuzzing/test_story.py
+++ b/tests/fuzzing/test_story.py
@@ -1,0 +1,54 @@
+from tests.fuzzing.story import Step, Story
+
+
+def test_step_narrative_formats_args():
+    step = Step(
+        action_name="create_catalogue",
+        args={"name": "MyCat"},
+        narrate_template="Created catalogue '{name}'",
+    )
+    assert step.narrative == "Created catalogue 'MyCat'"
+
+
+def test_step_narrative_with_result():
+    step = Step(
+        action_name="create_catalogue",
+        args={},
+        narrate_template="Created catalogue '{result}'",
+        result="cat-uuid-1",
+    )
+    assert step.narrative == "Created catalogue 'cat-uuid-1'"
+
+
+def test_step_as_code():
+    step = Step(
+        action_name="create_catalogue",
+        args={"name": "MyCat"},
+        narrate_template="",
+    )
+    assert step.as_code() == "actions.create_catalogue(name='MyCat')"
+
+
+def test_story_narrative_numbers_steps():
+    story = Story()
+    story.record(Step("a", {}, "Did A"))
+    story.record(Step("b", {"x": "1"}, "Did B with {x}"))
+    lines = story.narrative().split("\n")
+    assert lines[0] == "1. Did A"
+    assert lines[1] == "2. Did B with 1"
+
+
+def test_story_reproducer():
+    story = Story()
+    story.record(Step("create_catalogue", {}, ""))
+    story.record(Step("select", {"uuid": "abc"}, ""))
+    code = story.reproducer()
+    assert "def test_reproducer(gui, qtbot):" in code
+    assert "actions.create_catalogue()" in code
+    assert "actions.select(uuid='abc')" in code
+
+
+def test_empty_story():
+    story = Story()
+    assert story.narrative() == ""
+    assert "def test_reproducer" in story.reproducer()

--- a/tests/fuzzing/test_ui_fuzzing.py
+++ b/tests/fuzzing/test_ui_fuzzing.py
@@ -1,0 +1,34 @@
+import pytest
+from hypothesis.stateful import run_state_machine_as_test
+
+from tests.fuzzing.actions import ActionRegistry
+from tests.fuzzing.catalogue_actions import registry as cat_registry
+from tests.fuzzing.event_actions import registry as event_registry
+from tests.fuzzing.undo_actions import registry as undo_registry
+
+combined = ActionRegistry()
+for r in (cat_registry, event_registry, undo_registry):
+    combined.actions.extend(r.actions)
+
+TscatGUIFuzzer = combined.build_state_machine(
+    name="TscatGUIFuzzer",
+    max_examples=10,
+    stateful_step_count=10,
+)
+
+
+@pytest.mark.qt_no_exception_capture
+def test_ui_fuzzing(qtbot):
+    from tscat_gui import TSCatGUI
+    from tscat_gui.tscat_driver.driver import tscat_driver
+
+    widget = TSCatGUI()
+    qtbot.addWidget(widget)
+
+    TscatGUIFuzzer.gui = widget
+    TscatGUIFuzzer.qtbot = qtbot
+
+    try:
+        run_state_machine_as_test(TscatGUIFuzzer)
+    finally:
+        tscat_driver.setParent(None)

--- a/tests/fuzzing/test_wf_catalogue.py
+++ b/tests/fuzzing/test_wf_catalogue.py
@@ -1,0 +1,25 @@
+from tests.fuzzing.catalogue_actions import (
+    create_catalogue,
+    restore_catalogue,
+    select_catalogue,
+    trash_catalogue,
+)
+
+
+def test_create_and_select_catalogue(story_runner):
+    uuid = story_runner.run(create_catalogue)
+    assert uuid is not None
+
+    story_runner.run(select_catalogue, uuid=uuid)
+    assert uuid in story_runner.model.selected_catalogues
+
+
+def test_create_trash_and_restore(story_runner):
+    uuid = story_runner.run(create_catalogue)
+
+    story_runner.run(select_catalogue, uuid=uuid)
+    story_runner.run(trash_catalogue, uuid=uuid)
+    assert uuid in story_runner.model.trashed
+
+    story_runner.run(restore_catalogue, uuid=uuid)
+    assert uuid not in story_runner.model.trashed

--- a/tests/fuzzing/test_wf_catalogue.py
+++ b/tests/fuzzing/test_wf_catalogue.py
@@ -10,16 +10,16 @@ def test_create_and_select_catalogue(story_runner):
     uuid = story_runner.run(create_catalogue)
     assert uuid is not None
 
-    story_runner.run(select_catalogue, uuid=uuid)
+    story_runner.run(select_catalogue, idx=0)
     assert uuid in story_runner.model.selected_catalogues
 
 
 def test_create_trash_and_restore(story_runner):
     uuid = story_runner.run(create_catalogue)
 
-    story_runner.run(select_catalogue, uuid=uuid)
-    story_runner.run(trash_catalogue, uuid=uuid)
+    story_runner.run(select_catalogue, idx=0)
+    story_runner.run(trash_catalogue, idx=0)
     assert uuid in story_runner.model.trashed
 
-    story_runner.run(restore_catalogue, uuid=uuid)
+    story_runner.run(restore_catalogue, idx=0)
     assert uuid not in story_runner.model.trashed

--- a/tests/fuzzing/test_wf_edit.py
+++ b/tests/fuzzing/test_wf_edit.py
@@ -1,0 +1,28 @@
+from tests.fuzzing.attribute_actions import edit_catalogue_name, edit_event_dates
+from tests.fuzzing.catalogue_actions import create_catalogue, select_catalogue
+from tests.fuzzing.event_actions import create_event
+from tests.fuzzing.introspect import entity_attribute
+from tests.fuzzing.undo_actions import undo
+
+
+def test_edit_catalogue_name(story_runner):
+    uuid = story_runner.run(create_catalogue)
+    story_runner.run(edit_catalogue_name, idx=0, new_name="Renamed")
+    assert entity_attribute(story_runner.gui, uuid, "name") == "Renamed"
+
+
+def test_edit_catalogue_name_then_undo(story_runner):
+    uuid = story_runner.run(create_catalogue)
+    original = entity_attribute(story_runner.gui, uuid, "name")
+    story_runner.run(edit_catalogue_name, idx=0, new_name="Changed")
+    assert entity_attribute(story_runner.gui, uuid, "name") == "Changed"
+
+    story_runner.run(undo)
+    assert entity_attribute(story_runner.gui, uuid, "name") == original
+
+
+def test_edit_event_dates(story_runner):
+    story_runner.run(create_catalogue)
+    story_runner.run(select_catalogue, idx=0)
+    story_runner.run(create_event)
+    story_runner.run(edit_event_dates, idx=0, offset_hours=100)

--- a/tests/fuzzing/test_wf_events.py
+++ b/tests/fuzzing/test_wf_events.py
@@ -5,7 +5,7 @@ from tests.fuzzing.event_actions import create_event
 def test_create_catalogue_then_event(story_runner):
     cat_uuid = story_runner.run(create_catalogue)
 
-    story_runner.run(select_catalogue, uuid=cat_uuid)
+    story_runner.run(select_catalogue, idx=0)
     ev_uuid = story_runner.run(create_event)
 
     assert ev_uuid is not None

--- a/tests/fuzzing/test_wf_events.py
+++ b/tests/fuzzing/test_wf_events.py
@@ -1,0 +1,12 @@
+from tests.fuzzing.catalogue_actions import create_catalogue, select_catalogue
+from tests.fuzzing.event_actions import create_event
+
+
+def test_create_catalogue_then_event(story_runner):
+    cat_uuid = story_runner.run(create_catalogue)
+
+    story_runner.run(select_catalogue, uuid=cat_uuid)
+    ev_uuid = story_runner.run(create_event)
+
+    assert ev_uuid is not None
+    assert ev_uuid in story_runner.model.events.get(cat_uuid, [])

--- a/tests/fuzzing/test_wf_undo.py
+++ b/tests/fuzzing/test_wf_undo.py
@@ -1,0 +1,34 @@
+from tests.fuzzing.catalogue_actions import create_catalogue, select_catalogue
+from tests.fuzzing.event_actions import create_event
+from tests.fuzzing.introspect import catalogue_uuids, visible_event_count
+from tests.fuzzing.undo_actions import redo, undo
+
+
+def test_create_catalogue_and_undo(story_runner):
+    uuid = story_runner.run(create_catalogue)
+    assert uuid in catalogue_uuids(story_runner.gui)
+
+    story_runner.run(undo)
+    assert uuid not in catalogue_uuids(story_runner.gui)
+
+
+def test_create_catalogue_undo_redo(story_runner):
+    uuid = story_runner.run(create_catalogue)
+
+    story_runner.run(undo)
+    assert uuid not in catalogue_uuids(story_runner.gui)
+
+    story_runner.run(redo)
+    assert uuid in catalogue_uuids(story_runner.gui)
+
+
+def test_create_event_and_undo(story_runner):
+    cat_uuid = story_runner.run(create_catalogue)
+
+    story_runner.run(select_catalogue, uuid=cat_uuid)
+
+    story_runner.run(create_event)
+    assert visible_event_count(story_runner.gui) == 1
+
+    story_runner.run(undo)
+    assert visible_event_count(story_runner.gui) == 0

--- a/tests/fuzzing/test_wf_undo.py
+++ b/tests/fuzzing/test_wf_undo.py
@@ -23,9 +23,9 @@ def test_create_catalogue_undo_redo(story_runner):
 
 
 def test_create_event_and_undo(story_runner):
-    cat_uuid = story_runner.run(create_catalogue)
+    story_runner.run(create_catalogue)
 
-    story_runner.run(select_catalogue, uuid=cat_uuid)
+    story_runner.run(select_catalogue, idx=0)
 
     story_runner.run(create_event)
     assert visible_event_count(story_runner.gui) == 1

--- a/tests/fuzzing/undo_actions.py
+++ b/tests/fuzzing/undo_actions.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from tests.fuzzing.actions import ActionRegistry, settle, ui_action
+from tests.fuzzing.introspect import catalogue_uuids
+from tests.fuzzing.model import AppModel
+from tscat_gui import TSCatGUI
+
+registry = ActionRegistry()
+
+
+def _verify_catalogues(gui: TSCatGUI, model: AppModel) -> None:
+    live = set(catalogue_uuids(gui))
+    expected = {u for u in model.catalogues if u not in model.trashed}
+    assert live == expected, f"catalogues mismatch: live={live}, expected={expected}"
+
+
+@registry.register
+@ui_action(
+    narrate="Undo",
+    model_update=lambda model: model.pop_snapshot(),
+    verify=_verify_catalogues,
+    precondition=lambda model: model.has_undo,
+    manages_own_snapshots=True,
+    settle_timeout_ms=500,
+)
+def undo(gui: TSCatGUI, model: AppModel):
+    gui.state.undo_stack().undo()
+    settle(500)
+
+
+@registry.register
+@ui_action(
+    narrate="Redo",
+    model_update=lambda model: model.pop_redo(),
+    verify=_verify_catalogues,
+    precondition=lambda model: model.has_redo,
+    manages_own_snapshots=True,
+    settle_timeout_ms=500,
+)
+def redo(gui: TSCatGUI, model: AppModel):
+    gui.state.undo_stack().redo()
+    settle(500)

--- a/tscat_gui/__init__.py
+++ b/tscat_gui/__init__.py
@@ -501,6 +501,7 @@ class TSCatGUI(QtWidgets.QWidget):
         layout.addWidget(splitter)
         self.setLayout(layout)
 
+    @QtCore.Slot(Action)
     def _external_signal_emission_changed(self, action: Action) -> None:
         if isinstance(action, (SetAttributeAction, DeleteAttributeAction)) and action.entities:
             if isinstance(action.entities[0], _Catalogue):

--- a/tscat_gui/__init__.py
+++ b/tscat_gui/__init__.py
@@ -73,7 +73,7 @@ class TSCatGUI(QtWidgets.QWidget):
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
 
-        self.state = AppState()
+        self.state = AppState(self)
 
         from .tscat_driver.driver import tscat_driver
         tscat_driver.setParent(self)
@@ -87,6 +87,7 @@ class TSCatGUI(QtWidgets.QWidget):
 
         self.state.state_changed.connect(self.__state_changed)
 
+    @QtCore.Slot(str, type, list)
     def __state_changed(self, action: str, type: Union[Type[_Catalogue], Type[_Event]],
                         uuids: Sequence[str]) -> None:
         if action in ['active_select', 'passive_select']:
@@ -206,6 +207,7 @@ class TSCatGUI(QtWidgets.QWidget):
 
         toolbutton.setMenu(menu)
 
+    @QtCore.Slot(int)
     def __undo_redo_index_changed(self, index: int) -> None:
         max_action_count = 10
 

--- a/tscat_gui/__init__.py
+++ b/tscat_gui/__init__.py
@@ -104,7 +104,7 @@ class TSCatGUI(QtWidgets.QWidget):
 
                 current_models = set(self.event_model.sourceModels())
                 from .tscat_driver.model import tscat_model
-                new_models = set(map(tscat_model.catalog, uuids))
+                new_models = {m for m in map(tscat_model.catalog, uuids) if m is not None}
 
                 # Detach sort proxy during swaps so only one reset reaches the view
                 self.events_view.selectionModel().selectionChanged.disconnect(  # type: ignore

--- a/tscat_gui/edit.py
+++ b/tscat_gui/edit.py
@@ -319,7 +319,7 @@ class CustomAttributesGroupBox(AttributesGroupBox):
         self.setStyleSheet("QGroupBox { font-weight: bold; }")
 
     def setup(self, entities: List[Union[tscat._Catalogue, tscat._Event]]) -> None:
-        if len(entities) > 1:
+        if len(entities) != 1:
             self.hide()
             return
 

--- a/tscat_gui/metadata.py
+++ b/tscat_gui/metadata.py
@@ -7,7 +7,7 @@ from .model_base.constants import EntityRole
 
 def __total_event_count(catalogues: List[tscat._Catalogue]) -> str:
     from .tscat_driver.model import tscat_model
-    return str(sum(tscat_model.catalog(c.uuid).rowCount() for c in catalogues))
+    return str(sum(m.rowCount() for c in catalogues if (m := tscat_model.catalog(c.uuid)) is not None))
 
 
 def __global_start_stop_range(catalogues: List[tscat._Catalogue]) -> str:
@@ -15,6 +15,8 @@ def __global_start_stop_range(catalogues: List[tscat._Catalogue]) -> str:
     min_start, max_stop = None, None
     for c in catalogues:
         model = tscat_model.catalog(c.uuid)
+        if model is None:
+            continue
         for i in range(model.rowCount()):
             event = cast(tscat._Event, model.data(model.index(i, 0), EntityRole))
 

--- a/tscat_gui/state.py
+++ b/tscat_gui/state.py
@@ -54,6 +54,8 @@ class AppState(QtCore.QObject):
                     self._select_state.selected_catalogues = uuids[:]
             else:
                 log.debug(f'already active "{uuids}"')
+        elif action == 'passive_select' and ty == tscat._Catalogue:
+            self._select_state.selected_catalogues = uuids[:]
 
         log.debug(f'app-state-updated action:{action}, type:{ty}, uuids:{uuids}')
         self.state_changed.emit(action, ty, uuids)

--- a/tscat_gui/state.py
+++ b/tscat_gui/state.py
@@ -1,6 +1,6 @@
 import copy
 import dataclasses
-from typing import List, Type, Union
+from typing import List, Optional, Type, Union
 
 from PySide6 import QtCore, QtGui
 
@@ -21,8 +21,8 @@ class AppState(QtCore.QObject):
 
     undo_stack_clean_changed = QtCore.Signal(bool)
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, parent: Optional[QtCore.QObject] = None) -> None:
+        super().__init__(parent)
         self._select_state = SelectState([], tscat._Catalogue, [], [])
 
         self._undo_stack = QtGui.QUndoStack(self)

--- a/tscat_gui/state.py
+++ b/tscat_gui/state.py
@@ -25,8 +25,8 @@ class AppState(QtCore.QObject):
         super().__init__()
         self._select_state = SelectState([], tscat._Catalogue, [], [])
 
-        self._undo_stack = QtGui.QUndoStack()
-        self._undo_stack.cleanChanged.connect(lambda x: self.undo_stack_clean_changed.emit(x))  # type: ignore
+        self._undo_stack = QtGui.QUndoStack(self)
+        self._undo_stack.cleanChanged.connect(self.undo_stack_clean_changed)  # type: ignore
 
     def push_undo_command(self, cls, *args) -> None:
         self._undo_stack.push(cls(self, *args))

--- a/tscat_gui/tscat_driver/driver.py
+++ b/tscat_gui/tscat_driver/driver.py
@@ -78,8 +78,8 @@ class TscatDriver(QObject):
         self.action_done_prioritised.emit(action)
         self.action_done.emit(action)
 
-    def entity_from_uuid(self, uuid: str) -> Union[_Event, _Catalogue]:
-        return self._entity_cache[uuid]
+    def entity_from_uuid(self, uuid: str) -> Optional[Union[_Event, _Catalogue]]:
+        return self._entity_cache.get(uuid)
 
     def event_from_uuid(self, uuid: str) -> _Event:
         entity = self.entity_from_uuid(uuid)

--- a/tscat_gui/tscat_driver/model.py
+++ b/tscat_gui/tscat_driver/model.py
@@ -37,7 +37,7 @@ class _Model(QObject):
     @staticmethod
     def entities_from_uuids(uuids: Sequence[str]) -> List[Union[_Catalogue, _Event]]:
         from .driver import tscat_driver
-        return list(map(tscat_driver.entity_from_uuid, uuids))
+        return [e for e in map(tscat_driver.entity_from_uuid, uuids) if e is not None]
 
 
 tscat_model = _Model()

--- a/tscat_gui/tscat_driver/tscat_root_model.py
+++ b/tscat_gui/tscat_driver/tscat_root_model.py
@@ -253,14 +253,14 @@ class TscatRootModel(QAbstractItemModel):
             for node in list(map(CatalogNode, action.catalogues)):
                 self._insert_catalogue_node_at_node_path_or_trash(node)
 
-    def catalog(self, uuid: str) -> CatalogModel:
+    def catalog(self, uuid: str) -> Optional[CatalogModel]:
         if uuid not in self._catalogues:
             node = self._uuid_to_node.get(uuid)
             if isinstance(node, CatalogNode):
                 self._catalogues[uuid] = CatalogModel(node)
                 tscat_driver.do(GetCatalogueAction(None, removed_items=False, uuid=uuid))
 
-        return self._catalogues[uuid]
+        return self._catalogues.get(uuid)
 
     def current_path(self, index: Union[QModelIndex, QPersistentModelIndex]) -> List[str]:
         if not index.isValid():

--- a/tscat_gui/undo.py
+++ b/tscat_gui/undo.py
@@ -195,6 +195,12 @@ class NewEvent(_EntityBased):
     def _redo(self):
         from .tscat_driver.model import tscat_model
 
+        if not self._select_state.selected_catalogues:
+            log.warning("NewEvent._redo() called with no catalogue selected, skipping")
+            return
+
+        catalogue_uuid = self._select_state.selected_catalogues[0]
+
         def add_to_catalogue_callback(action: AddEventsToCatalogueAction) -> None:
             assert self.uuid is not None
             self._select([self.uuid], tscat._Event)
@@ -203,7 +209,7 @@ class NewEvent(_EntityBased):
             self.uuid = action.entity.uuid
             assert self.uuid is not None  # satisfy mypy
             tscat_model.do(AddEventsToCatalogueAction(add_to_catalogue_callback,
-                                                      [self.uuid], self._select_state.selected_catalogues[0]))
+                                                      [self.uuid], catalogue_uuid))
 
         tscat_model.do(CreateEntityAction(creation_callback, tscat._Event,
                                           {

--- a/tscat_gui/utils/helper.py
+++ b/tscat_gui/utils/helper.py
@@ -87,7 +87,7 @@ class DateTimeDelegate(QtWidgets.QDateTimeEdit):
         super().__init__(dt.datetime.now() if value is None else value, parent)  # type: ignore
         self.setDisplayFormat("yyyy-MM-dd HH:mm:ss:zzz")
         self.setCalendarPopup(True)
-        self.setTimeSpec(QtCore.Qt.TimeSpec.UTC)
+        self.setTimeZone(QtCore.QTimeZone(QtCore.QTimeZone.Initialization.UTC))
 
     def value(self) -> dt.datetime:
         return cast(dt.datetime, self.dateTime().toPython())

--- a/uv.lock
+++ b/uv.lock
@@ -1561,23 +1561,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/9664130905f03db57961b8980b05cab624afd114bf2be2576628a9f22da4/sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096", size = 1940202, upload-time = "2026-03-02T15:52:43.285Z" },
 ]
 
-[package.optional-dependencies]
-mypy = [
-    { name = "mypy" },
-]
-
-[[package]]
-name = "sqlalchemy-utils"
-version = "0.42.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sqlalchemy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/7d/eb9565b6a49426552a5bf5c57e7c239c506dc0e4e5315aec6d1e8241dc7c/sqlalchemy_utils-0.42.1.tar.gz", hash = "sha256:881f9cd9e5044dc8f827bccb0425ce2e55490ce44fc0bb848c55cc8ee44cc02e", size = 130789, upload-time = "2025-12-13T03:14:13.591Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/25/7400c18c3ee97914cc99c90007795c00a4ec5b60c853b49db7ba24d11179/sqlalchemy_utils-0.42.1-py3-none-any.whl", hash = "sha256:243cfe1b3a1dae3c74118ae633f1d1e0ed8c787387bc33e556e37c990594ac80", size = 91761, upload-time = "2025-12-13T03:14:15.014Z" },
-]
-
 [[package]]
 name = "tomli"
 version = "2.4.0"
@@ -1634,7 +1617,7 @@ wheels = [
 
 [[package]]
 name = "tscat"
-version = "0.4.4"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -1642,13 +1625,12 @@ dependencies = [
     { name = "astropy", version = "6.1.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "astropy", version = "7.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "orjson" },
-    { name = "sqlalchemy", extra = ["mypy"] },
-    { name = "sqlalchemy-utils" },
+    { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/02/1563ea4248397d2195aed1aa52a51867906e3baa143e38e6f6aa7e45cd39/tscat-0.4.4.tar.gz", hash = "sha256:56b6d21413efa074db8adc845eed8d5f47987bd259cdaffd5201a8a00f0ae6d2", size = 22385, upload-time = "2025-11-06T16:41:22.06Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/e0/6629b9cee90954670bc093dc89922f93cb7c3f6b4776d3755c4fadf3e0f8/tscat-0.5.1.tar.gz", hash = "sha256:1f7fb6750c05534f042542c754f5a6d5e92b38b184891e7c37952c593e9e8b5e", size = 58398, upload-time = "2026-05-10T21:19:27.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/a8/5ec07323126ddc18c710bcc592aa27eabeef071193d9afc86f787e2598fb/tscat-0.4.4-py3-none-any.whl", hash = "sha256:f67b2ba2b046d331d53f22ac634a1fa59bb3b9d0d886a40a70cfb47f6e386a54", size = 25967, upload-time = "2025-11-06T16:41:21.203Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3c/60c1b465f3cc4422284b01ce3c49a5a550aea96b896eca4bb9c1652b75c7/tscat-0.5.1-py3-none-any.whl", hash = "sha256:5604b084c3f59a3fefbb20683403b87f03de42b635c95179f5fae31cce012c0e", size = 31224, upload-time = "2026-05-10T21:19:28.873Z" },
 ]
 
 [[package]]
@@ -1701,7 +1683,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'doc'" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'doc'" },
     { name = "sphinx-rtd-theme", marker = "extra == 'doc'" },
-    { name = "tscat", specifier = "==0.4.*" },
+    { name = "tscat", specifier = ">=0.5.1,<0.6" },
 ]
 provides-extras = ["test", "doc"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -457,6 +457,19 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.151.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e1/ef365ff480903b929d28e057f57b76cae51a30375943e33374ec9a165d9c/hypothesis-6.151.9.tar.gz", hash = "sha256:2f284428dda6c3c48c580de0e18470ff9c7f5ef628a647ee8002f38c3f9097ca", size = 463534, upload-time = "2026-02-16T22:59:23.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl", hash = "sha256:7b7220585c67759b1b1ef839b1e6e9e3d82ed468cfc1ece43c67184848d7edd9", size = 529307, upload-time = "2026-02-16T22:59:20.443Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -1257,6 +1270,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "sphinx"
 version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1650,25 +1672,32 @@ doc = [
 ]
 test = [
     { name = "ddt" },
+    { name = "hypothesis" },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
     { name = "pytest-timeout" },
+    { name = "ruff" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "ddt", marker = "extra == 'test'" },
+    { name = "hypothesis", marker = "extra == 'test'" },
+    { name = "mypy", marker = "extra == 'test'" },
     { name = "pyside6" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=4.6.5" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pytest-qt", marker = "extra == 'test'" },
     { name = "pytest-timeout", marker = "extra == 'test'" },
+    { name = "ruff", marker = "extra == 'test'", specifier = ">=0.15.6" },
     { name = "sphinx", marker = "extra == 'doc'" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'doc'" },
     { name = "sphinx-rtd-theme", marker = "extra == 'doc'" },
@@ -1677,7 +1706,10 @@ requires-dist = [
 provides-extras = ["test", "doc"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.6" }]
+dev = [
+    { name = "mypy" },
+    { name = "ruff", specifier = ">=0.15.6" },
+]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## Summary

- Ports the story-driven UI fuzzing framework from SciQLop to tscat_gui
- Adds Hypothesis-based state machine fuzzer that explores random action sequences with automatic shrinking
- 16 actions: catalogue CRUD, event CRUD, custom attribute CRUD, built-in field editing (name, start/stop), undo/redo
- Human-readable failure narratives and auto-generated reproducer scripts
- Fixes 4 bugs found by the fuzzer:
  - `entity_from_uuid` KeyError on stale UUIDs after entity removal
  - `NewEvent._redo()` IndexError when `selected_catalogues` is empty
  - `AttributesEditWidget.setup()` IndexError on empty entities list
  - `TscatRootModel.catalog()` KeyError for removed catalogue UUIDs

## Test plan

- [x] 132 unit/workflow tests pass
- [x] Ruff and mypy clean
- [x] Fuzzer passes 3+ consecutive clean runs
- [x] Scripted workflow tests cover all action types including edit operations
- [x] Temp DB safety guard prevents writes to real catalogues

🤖 Generated with [Claude Code](https://claude.com/claude-code)